### PR TITLE
Fix issue about mobs spawning in fortress

### DIFF
--- a/abms.lua
+++ b/abms.lua
@@ -50,7 +50,8 @@ minetest.register_globalstep(function(dtime)
 		local minp = vector.subtract(pos, 0.5)
 		local maxp = vector.add(pos, 0.5)
 
-		if dps_count % monster_delay == 0 then
+		if fun_caves.fortress_spawns
+				and dps_count % monster_delay == 0 then
 			local mob_count = 0
 			for _, mob in pairs(minetest.luaentities) do
 				if mob.health and mob.started_in_fortress then


### PR DESCRIPTION
To fix this issue, that occurs when you don't have any mobs mod:
```
2016-06-14 14:21:12: ERROR[Main]: ServerError: Runtime error from mod 'fun_caves' in callback environment_Step(): /home/gael/.minetest/mods/fun_caves/abms.lua:74: attempt to get length of field 'fortress_spawns' (a nil value)
2016-06-14 14:21:12: ERROR[Main]: stack traceback:
2016-06-14 14:21:12: ERROR[Main]: 	/home/gael/.minetest/mods/fun_caves/abms.lua:74: in function </home/gael/.minetest/mods/fun_caves/abms.lua:17>
2016-06-14 14:21:12: ERROR[Main]: 	/usr/share/minetest/builtin/game/register.lua:369: in function </usr/share/minetest/builtin/game/register.lua:349>
```